### PR TITLE
change path from Resources to resources

### DIFF
--- a/src/Traits/CommandHelper.php
+++ b/src/Traits/CommandHelper.php
@@ -118,7 +118,7 @@ trait CommandHelper
 
     protected function getModuleLivewireViewDir()
     {
-        $moduleLivewireViewDir = config('modules-livewire.view', 'Resources/views/livewire');
+        $moduleLivewireViewDir = config('modules-livewire.view', 'resources/views/livewire');
 
         if ($this->isCustomModule()) {
             $moduleLivewireViewDir = config("modules-livewire.custom_modules.{$this->module}.view", $moduleLivewireViewDir);


### PR DESCRIPTION
In Laravel modules version 10, the resource paths are in lowercase. Therefore, this pull request adjusts the resource paths from uppercase to lowercase to align with the convention used in version 10 of Laravel modules.