### PR TITLE
Update namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,9 @@
             "role": "Developer"
         }
     ],
+    "conflict": {
+        "nwidart/laravel-modules": ">=11.0.0"
+    },
     "type": "library",
     "require": {
         "php": ">=8.1",

--- a/src/Providers/LivewireComponentServiceProvider.php
+++ b/src/Providers/LivewireComponentServiceProvider.php
@@ -46,7 +46,7 @@ class LivewireComponentServiceProvider extends ServiceProvider
         $modulesLivewireNamespace = config('modules-livewire.namespace', 'Livewire');
 
         $modules->each(function ($module) use ($modulesLivewireNamespace) {
-            $directory = (string) Str::of($module->getPath())
+            $directory = (string) Str::of($module->getAppPath())
                 ->append('/'.$modulesLivewireNamespace)
                 ->replace(['\\'], '/');
 

--- a/src/Traits/CommandHelper.php
+++ b/src/Traits/CommandHelper.php
@@ -75,11 +75,11 @@ trait CommandHelper
             : $this->module->getLowerName();
     }
 
-    protected function getModulePath()
+    protected function getModulePath($withApp = false)
     {
         $path = $this->isCustomModule()
             ? config("modules-livewire.custom_modules.{$this->module}.path")
-            : $this->module->getPath();
+            : ($withApp ? $this->module->getAppPath() : $this->module->getPath());
 
         return strtr($path, ['\\' => '/']);
     }

--- a/src/Traits/ComponentParser.php
+++ b/src/Traits/ComponentParser.php
@@ -60,7 +60,7 @@ trait ComponentParser
 
     protected function getClassInfo()
     {
-        $modulePath = $this->getModulePath();
+        $modulePath = $this->getModulePath(true);
 
         $moduleLivewireNamespace = $this->getModuleLivewireNamespace();
 


### PR DESCRIPTION
Hi,

In this PR, I've updated the generated class with the new structure of the modular system. You can find more details in [#1758 laravel module](https://github.com/nWidart/laravel-modules/pull/1758).

> The method `getAppPath` has been added in this Pull Request: [#1768](https://github.com/nWidart/laravel-modules/pull/1768).
## Before:
<img width="305" alt="image" src="https://github.com/mhmiton/laravel-modules-livewire/assets/26966142/041ce4f9-79fd-4e67-899b-c6a0a2e82838">

## After:
<img width="314" alt="image" src="https://github.com/mhmiton/laravel-modules-livewire/assets/26966142/52656533-d91c-4659-a10f-3fe4e3d5c46c">

Additionally, I've added a conflict section to the composer JSON to prevent errors on older versions:
```json
"conflict": {
    "nwidart/laravel-modules": ">=11.0.0"
}, 
```

