### PR TITLE
style: Apply Laravel Pint code style fixes across src and tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
     "require-dev": {
         "mockery/mockery": "^1.6",
         "phpunit/phpunit": "^10.4|^11.5|^12.0",
-        "orchestra/testbench": "^8.21.0|^9.0|^10.0|^11.0"
+        "orchestra/testbench": "^8.21.0|^9.0|^10.0|^11.0",
+        "laravel/pint": "^1.29"
     },
     "extra": {
         "laravel": {
@@ -53,7 +54,8 @@
     },
     "scripts": {
         "test": "composer dump-autoload && phpunit",
-        "test-quick": "phpunit"
+        "test-quick": "phpunit",
+        "lint": "pint"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/src/Commands/LivewireMakeCommand.php
+++ b/src/Commands/LivewireMakeCommand.php
@@ -88,7 +88,7 @@ class LivewireMakeCommand extends Command implements PromptsForMissingInput
             file_get_contents($this->component->stub->mfc_stubs['class'])
         );
 
-        $this->line("<options=bold;fg=green>CLASS:</>  ".strtr($this->getViewSourcePath(), ['.blade.php' => '.php']));
+        $this->line('<options=bold;fg=green>CLASS:</>  '.strtr($this->getViewSourcePath(), ['.blade.php' => '.php']));
 
         File::put(
             $viewFile,
@@ -111,7 +111,7 @@ class LivewireMakeCommand extends Command implements PromptsForMissingInput
                 )
             );
 
-            $this->line("<options=bold;fg=green>TEST:</>  ".strtr($this->getViewSourcePath(), ['.blade.php' => '.test.php']));
+            $this->line('<options=bold;fg=green>TEST:</>  '.strtr($this->getViewSourcePath(), ['.blade.php' => '.test.php']));
         }
 
         if ($this->option('js') || config('livewire.make_command.with.js')) {
@@ -120,7 +120,7 @@ class LivewireMakeCommand extends Command implements PromptsForMissingInput
                 file_get_contents($this->component->stub->mfc_stubs['js'])
             );
 
-            $this->line("<options=bold;fg=green>JS:</>  ".strtr($this->getViewSourcePath(), ['.blade.php' => '.js']));
+            $this->line('<options=bold;fg=green>JS:</>  '.strtr($this->getViewSourcePath(), ['.blade.php' => '.js']));
         }
 
         $this->line("<options=bold;fg=green>TAG:</> {$this->component->view->tag}");

--- a/src/Providers/LivewireComponentServiceProvider.php
+++ b/src/Providers/LivewireComponentServiceProvider.php
@@ -8,6 +8,7 @@ use Livewire\Livewire;
 use Mhmiton\LaravelModulesLivewire\Support\Decomposer;
 use Mhmiton\LaravelModulesLivewire\Support\ModuleVoltComponentRegistry;
 use Mhmiton\LaravelModulesLivewire\View\ModuleVoltViewFactory;
+use Nwidart\Modules\Facades\Module;
 
 class LivewireComponentServiceProvider extends ServiceProvider
 {
@@ -41,7 +42,7 @@ class LivewireComponentServiceProvider extends ServiceProvider
             return false;
         }
 
-        $modules = \Nwidart\Modules\Facades\Module::toCollection();
+        $modules = Module::toCollection();
 
         $modulesLivewireNamespace = config('modules-livewire.namespace', 'Livewire');
 

--- a/src/Support/Decomposer.php
+++ b/src/Support/Decomposer.php
@@ -12,7 +12,7 @@ class Decomposer
     public static function getComposerData()
     {
         try {
-            $composer = (new Filesystem())->get(base_path('composer.lock'));
+            $composer = (new Filesystem)->get(base_path('composer.lock'));
 
             return collect(data_get(json_decode($composer, true), 'packages'));
         } catch (\Exception $e) {
@@ -44,7 +44,7 @@ class Decomposer
 
     public static function hasPackages($packageNames = [])
     {
-        $packages = $packageNames ?? (new static())->dependencies;
+        $packages = $packageNames ?? (new static)->dependencies;
 
         foreach ($packages as $v) {
             if (! self::getPackage($v)) {
@@ -58,7 +58,7 @@ class Decomposer
 
     public static function checkDependencies($packageNames = null)
     {
-        $packages = $packageNames ?? (new static())->dependencies;
+        $packages = $packageNames ?? (new static)->dependencies;
 
         $type = 'success';
 

--- a/src/Support/ModuleVoltComponentRegistry.php
+++ b/src/Support/ModuleVoltComponentRegistry.php
@@ -4,12 +4,14 @@ namespace Mhmiton\LaravelModulesLivewire\Support;
 
 use Illuminate\Support\Str;
 use Livewire\Livewire;
+use Livewire\Volt\ComponentFactory;
+use Livewire\Volt\Volt;
 
 class ModuleVoltComponentRegistry
 {
     public function registerComponents($options = [])
     {
-        if (! class_exists(\Livewire\Volt\Volt::class)) {
+        if (! class_exists(Volt::class)) {
             return false;
         }
 
@@ -50,13 +52,13 @@ class ModuleVoltComponentRegistry
 
                 return $registerableComponent;
             })
-                ->filter()
-                ->values()
-                ->all();
+            ->filter()
+            ->values()
+            ->all();
 
         return [
             'registerableComponents' => $registerableComponents,
-            'registeredComponents' => $registeredComponents
+            'registeredComponents' => $registeredComponents,
         ];
     }
 
@@ -75,7 +77,7 @@ class ModuleVoltComponentRegistry
                 }
 
                 $fileToComponents = collect(\File::allFiles($fullViewPath))
-                    ->filter(fn($file) => str_ends_with($file->getFilename(), '.blade.php'))
+                    ->filter(fn ($file) => str_ends_with($file->getFilename(), '.blade.php'))
                     ->map(function ($file) use ($aliasPrefix, $viewPath) {
                         $view = (string) Str::of($file->getPathname())
                             ->afterLast($viewPath)
@@ -152,12 +154,12 @@ class ModuleVoltComponentRegistry
             ->map(fn ($viewNamespace) => data_get($moduleComponentData, 'view_path_full').'/'.$viewNamespace)
             ->all();
 
-        \Livewire\Volt\Volt::mount($mountPaths);
+        Volt::mount($mountPaths);
     }
 
     public function component($alias, $path)
     {
-        $componentClass = app(\Livewire\Volt\ComponentFactory::class)->make($alias, $path);
+        $componentClass = app(ComponentFactory::class)->make($alias, $path);
 
         Livewire::component($alias, $componentClass);
     }
@@ -190,7 +192,7 @@ class ModuleVoltComponentRegistry
             $moduleVoltView = "{$moduleName}::{$moduleVoltViewNamespace}.{$componentWithoutAlias}";
 
             if (view()->exists($moduleVoltView)) {
-                return app(\Livewire\Volt\ComponentFactory::class)
+                return app(ComponentFactory::class)
                     ->make($component, view()->getFinder()->find($moduleVoltView));
             }
         }

--- a/src/Traits/LivewireComponentParser.php
+++ b/src/Traits/LivewireComponentParser.php
@@ -263,7 +263,7 @@ trait LivewireComponentParser
 
     protected function getComponentQuote()
     {
-        return "The <code>{$this->getComponentTagName()}</code> ".$this->determineComponentType()." component is loaded from the ".($this->isCustomModule() ? 'custom ' : '')."<code>{$this->getModuleName()}</code> module.";
+        return "The <code>{$this->getComponentTagName()}</code> ".$this->determineComponentType().' component is loaded from the '.($this->isCustomModule() ? 'custom ' : '')."<code>{$this->getModuleName()}</code> module.";
     }
 
     protected function getBasePath($path = null)

--- a/src/Traits/VoltComponentParser.php
+++ b/src/Traits/VoltComponentParser.php
@@ -76,7 +76,7 @@ trait VoltComponentParser
 
     protected function getModuleVoltComponentData()
     {
-        return (new ModuleVoltComponentRegistry())->getModuleComponentData(
+        return (new ModuleVoltComponentRegistry)->getModuleComponentData(
             $this->getModuleLowerName()
         );
     }

--- a/src/View/ModuleVoltViewFactory.php
+++ b/src/View/ModuleVoltViewFactory.php
@@ -2,8 +2,8 @@
 
 namespace Mhmiton\LaravelModulesLivewire\View;
 
-use Illuminate\View\Factory;
 use Illuminate\Support\Str;
+use Illuminate\View\Factory;
 use Mhmiton\LaravelModulesLivewire\Support\ModuleVoltComponentRegistry;
 
 class ModuleVoltViewFactory extends Factory
@@ -27,7 +27,7 @@ class ModuleVoltViewFactory extends Factory
             ->replace(['volt-livewire::'], '')
             ->toString();
 
-        $moduleComponentData = (new ModuleVoltComponentRegistry())->getModuleComponentData($moduleName);
+        $moduleComponentData = (new ModuleVoltComponentRegistry)->getModuleComponentData($moduleName);
 
         $moduleVoltViewNamespaces = data_get($moduleComponentData, 'volt_view_namespaces');
 

--- a/tests/Feature/Commands/LivewireMakeCommandTest.php
+++ b/tests/Feature/Commands/LivewireMakeCommandTest.php
@@ -7,7 +7,7 @@ use Mhmiton\LaravelModulesLivewire\Tests\TestCase;
 
 class LivewireMakeCommandTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
     }
@@ -23,9 +23,9 @@ class LivewireMakeCommandTest extends TestCase
     {
         $this->artisan('module:make-livewire', [
             'component' => 'Pages/AboutPage',
-            'module' => 'Core'
+            'module' => 'Core',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
 
         $this->assertFileExists(base_path('Modules/Core/app/Livewire/Pages/AboutPage.php'));
         $this->assertFileExists(base_path('Modules/Core/resources/views/livewire/pages/about-page.blade.php'));
@@ -35,9 +35,9 @@ class LivewireMakeCommandTest extends TestCase
     {
         $this->artisan('module:make-livewire', [
             'component' => 'Pages\\AboutPage',
-            'module' => 'Core'
+            'module' => 'Core',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
 
         $this->assertFileExists(base_path('Modules/Core/app/Livewire/Pages/AboutPage.php'));
     }
@@ -46,9 +46,9 @@ class LivewireMakeCommandTest extends TestCase
     {
         $this->artisan('module:make-livewire', [
             'component' => 'pages.about-page',
-            'module' => 'Core'
+            'module' => 'Core',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
 
         $this->assertFileExists(base_path('Modules/Core/app/Livewire/Pages/AboutPage.php'));
     }
@@ -58,9 +58,9 @@ class LivewireMakeCommandTest extends TestCase
         $this->artisan('module:make-livewire', [
             'component' => 'Pages/AboutPage',
             'module' => 'Core',
-            '--inline' => true
+            '--inline' => true,
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
 
         $this->assertFileExists(base_path('Modules/Core/app/Livewire/Pages/AboutPage.php'));
         $this->assertFileDoesNotExist(base_path('Modules/Core/resources/views/livewire/pages/about-page.blade.php'));
@@ -71,17 +71,17 @@ class LivewireMakeCommandTest extends TestCase
         // Create the component first
         $this->artisan('module:make-livewire', [
             'component' => 'Pages/AboutPage',
-            'module' => 'Core'
+            'module' => 'Core',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
 
         // Try to create it again with force
         $this->artisan('module:make-livewire', [
             'component' => 'Pages/AboutPage',
             'module' => 'Core',
-            '--force' => true
+            '--force' => true,
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
     }
 
     public function test_cannot_create_component_without_force_when_exists()
@@ -89,16 +89,16 @@ class LivewireMakeCommandTest extends TestCase
         // Create the component first
         $this->artisan('module:make-livewire', [
             'component' => 'Pages/AboutPage',
-            'module' => 'Core'
+            'module' => 'Core',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
 
         // Try to create it again without force
         $this->artisan('module:make-livewire', [
             'component' => 'Pages/AboutPage',
-            'module' => 'Core'
+            'module' => 'Core',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
     }
 
     public function test_can_create_component_with_custom_view_path()
@@ -106,9 +106,9 @@ class LivewireMakeCommandTest extends TestCase
         $this->artisan('module:make-livewire', [
             'component' => 'Pages/AboutPage',
             'module' => 'Core',
-            '--view' => 'pages/about'
+            '--view' => 'pages/about',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
 
         $this->assertFileExists(base_path('Modules/Core/resources/views/livewire/pages/about.blade.php'));
     }
@@ -118,14 +118,14 @@ class LivewireMakeCommandTest extends TestCase
         // Create custom stub directory
         $stubPath = base_path('stubs/modules-livewire/custom');
         File::makeDirectory($stubPath, 0755, true, true);
-        File::put($stubPath . '/livewire.stub', '<?php namespace {{ namespace }}; class {{ class }} { }');
+        File::put($stubPath.'/livewire.stub', '<?php namespace {{ namespace }}; class {{ class }} { }');
 
         $this->artisan('module:make-livewire', [
             'component' => 'Pages/AboutPage',
             'module' => 'Core',
-            '--stub' => 'custom'
+            '--stub' => 'custom',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
 
         // Clean up
         File::deleteDirectory($stubPath);
@@ -135,17 +135,17 @@ class LivewireMakeCommandTest extends TestCase
     {
         $this->artisan('module:make-livewire', [
             'component' => '123Invalid',
-            'module' => 'Core'
+            'module' => 'Core',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
     }
 
     public function test_validates_reserved_class_names()
     {
         $this->artisan('module:make-livewire', [
             'component' => 'Component',
-            'module' => 'Core'
+            'module' => 'Core',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
     }
 }

--- a/tests/Feature/Commands/LivewireMakeFormCommandTest.php
+++ b/tests/Feature/Commands/LivewireMakeFormCommandTest.php
@@ -7,7 +7,7 @@ use Mhmiton\LaravelModulesLivewire\Tests\TestCase;
 
 class LivewireMakeFormCommandTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -27,9 +27,9 @@ class LivewireMakeFormCommandTest extends TestCase
     {
         $this->artisan('module:make-livewire-form', [
             'component' => 'Forms/PostForm',
-            'module' => 'Core'
+            'module' => 'Core',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
 
         $this->assertFileExists(base_path('Modules/Core/app/Livewire/Forms/PostForm.php'));
     }
@@ -38,9 +38,9 @@ class LivewireMakeFormCommandTest extends TestCase
     {
         $this->artisan('module:make-livewire-form', [
             'component' => 'Forms\\PostForm',
-            'module' => 'Core'
+            'module' => 'Core',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
 
         $this->assertFileExists(base_path('Modules/Core/app/Livewire/Forms/PostForm.php'));
     }
@@ -49,9 +49,9 @@ class LivewireMakeFormCommandTest extends TestCase
     {
         $this->artisan('module:make-livewire-form', [
             'component' => 'forms.post-form',
-            'module' => 'Core'
+            'module' => 'Core',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
 
         $this->assertFileExists(base_path('Modules/Core/app/Livewire/Forms/PostForm.php'));
     }
@@ -61,17 +61,17 @@ class LivewireMakeFormCommandTest extends TestCase
         // Create the component first
         $this->artisan('module:make-livewire-form', [
             'component' => 'Forms/PostForm',
-            'module' => 'Core'
+            'module' => 'Core',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
 
         // Try to create it again with force
         $this->artisan('module:make-livewire-form', [
             'component' => 'Forms/PostForm',
             'module' => 'Core',
-            '--force' => true
+            '--force' => true,
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
     }
 
     public function test_cannot_create_form_component_without_force_when_exists()
@@ -79,16 +79,16 @@ class LivewireMakeFormCommandTest extends TestCase
         // Create the component first
         $this->artisan('module:make-livewire-form', [
             'component' => 'Forms/PostForm',
-            'module' => 'Core'
+            'module' => 'Core',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
 
         // Try to create it again without force
         $this->artisan('module:make-livewire-form', [
             'component' => 'Forms/PostForm',
-            'module' => 'Core'
+            'module' => 'Core',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
     }
 
     public function test_can_create_form_component_with_custom_stub()
@@ -96,14 +96,14 @@ class LivewireMakeFormCommandTest extends TestCase
         // Create custom stub directory
         $stubPath = base_path('stubs/modules-livewire/custom');
         File::makeDirectory($stubPath, 0755, true, true);
-        File::put($stubPath . '/livewire.form.stub', '<?php namespace {{ namespace }}; class {{ class }} { }');
+        File::put($stubPath.'/livewire.form.stub', '<?php namespace {{ namespace }}; class {{ class }} { }');
 
         $this->artisan('module:make-livewire-form', [
             'component' => 'Forms/PostForm',
             'module' => 'Core',
-            '--stub' => 'custom'
+            '--stub' => 'custom',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
 
         // Clean up
         File::deleteDirectory($stubPath);
@@ -113,18 +113,18 @@ class LivewireMakeFormCommandTest extends TestCase
     {
         $this->artisan('module:make-livewire-form', [
             'component' => '123Invalid',
-            'module' => 'Core'
+            'module' => 'Core',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
     }
 
     public function test_validates_reserved_form_class_names()
     {
         $this->artisan('module:make-livewire-form', [
             'component' => 'Component',
-            'module' => 'Core'
+            'module' => 'Core',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
     }
 
     protected function createTestModule()
@@ -132,14 +132,14 @@ class LivewireMakeFormCommandTest extends TestCase
         $modulePath = base_path('Modules/Core');
 
         // Create module directory structure
-        File::makeDirectory($modulePath . '/app/Livewire', 0755, true, true);
-        File::makeDirectory($modulePath . '/resources/views/livewire', 0755, true, true);
+        File::makeDirectory($modulePath.'/app/Livewire', 0755, true, true);
+        File::makeDirectory($modulePath.'/resources/views/livewire', 0755, true, true);
 
         // Create module.json
-        File::put($modulePath . '/module.json', json_encode([
+        File::put($modulePath.'/module.json', json_encode([
             'name' => 'Core',
             'alias' => 'core',
-            'namespace' => 'Modules\\Core'
+            'namespace' => 'Modules\\Core',
         ]));
     }
 

--- a/tests/Feature/Commands/VoltMakeCommandTest.php
+++ b/tests/Feature/Commands/VoltMakeCommandTest.php
@@ -7,7 +7,7 @@ use Mhmiton\LaravelModulesLivewire\Tests\TestCase;
 
 class VoltMakeCommandTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -27,18 +27,18 @@ class VoltMakeCommandTest extends TestCase
     {
         $this->artisan('module:make-volt', [
             'component' => 'volt.counter',
-            'module' => 'Core'
+            'module' => 'Core',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
     }
 
     public function test_can_create_volt_component_with_slash_notation()
     {
         $this->artisan('module:make-volt', [
             'component' => 'volt/counter',
-            'module' => 'Core'
+            'module' => 'Core',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
     }
 
     public function test_can_force_create_volt_component()
@@ -46,17 +46,17 @@ class VoltMakeCommandTest extends TestCase
         // Create the component first
         $this->artisan('module:make-volt', [
             'component' => 'volt.counter',
-            'module' => 'Core'
+            'module' => 'Core',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
 
         // Try to create it again with force
         $this->artisan('module:make-volt', [
             'component' => 'volt.counter',
             'module' => 'Core',
-            '--force' => true
+            '--force' => true,
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
     }
 
     public function test_cannot_create_volt_component_without_force_when_exists()
@@ -64,34 +64,34 @@ class VoltMakeCommandTest extends TestCase
         // Create the component first
         $this->artisan('module:make-volt', [
             'component' => 'volt.counter',
-            'module' => 'Core'
+            'module' => 'Core',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
 
         // Try to create it again without force
         $this->artisan('module:make-volt', [
             'component' => 'volt.counter',
-            'module' => 'Core'
+            'module' => 'Core',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
     }
 
     public function test_can_create_volt_component_with_custom_view_namespace()
     {
         $this->artisan('module:make-volt', [
             'component' => 'volt.counter',
-            'module' => 'Core'
+            'module' => 'Core',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
     }
 
     public function test_can_create_volt_component_with_pages_view_namespace()
     {
         $this->artisan('module:make-volt', [
             'component' => 'pages.home',
-            'module' => 'Core'
+            'module' => 'Core',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
     }
 
     public function test_can_create_class_based_volt_component()
@@ -99,9 +99,9 @@ class VoltMakeCommandTest extends TestCase
         $this->artisan('module:make-volt', [
             'component' => 'volt.counter',
             'module' => 'Core',
-            '--class' => true
+            '--class' => true,
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
     }
 
     public function test_can_create_functional_volt_component()
@@ -109,9 +109,9 @@ class VoltMakeCommandTest extends TestCase
         $this->artisan('module:make-volt', [
             'component' => 'volt.counter',
             'module' => 'Core',
-            '--functional' => true
+            '--functional' => true,
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
     }
 
     public function test_can_create_volt_component_with_custom_stub()
@@ -119,14 +119,14 @@ class VoltMakeCommandTest extends TestCase
         // Create custom stub directory
         $stubPath = base_path('stubs/modules-livewire/custom');
         File::makeDirectory($stubPath, 0755, true, true);
-        File::put($stubPath . '/volt-component.stub', '<div>Test Volt Component</div>');
+        File::put($stubPath.'/volt-component.stub', '<div>Test Volt Component</div>');
 
         $this->artisan('module:make-volt', [
             'component' => 'volt.counter',
             'module' => 'Core',
-            '--stub' => 'custom'
+            '--stub' => 'custom',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
 
         // Clean up
         File::deleteDirectory($stubPath);
@@ -136,9 +136,9 @@ class VoltMakeCommandTest extends TestCase
     {
         $this->artisan('module:make-volt', [
             'component' => '123Invalid',
-            'module' => 'Core'
+            'module' => 'Core',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
     }
 
     protected function createTestModule()
@@ -146,14 +146,14 @@ class VoltMakeCommandTest extends TestCase
         $modulePath = base_path('modules/Core');
 
         // Create module directory structure
-        File::makeDirectory($modulePath . '/resources/views/livewire', 0755, true, true);
-        File::makeDirectory($modulePath . '/resources/views/pages', 0755, true, true);
+        File::makeDirectory($modulePath.'/resources/views/livewire', 0755, true, true);
+        File::makeDirectory($modulePath.'/resources/views/pages', 0755, true, true);
 
         // Create module.json
-        File::put($modulePath . '/module.json', json_encode([
+        File::put($modulePath.'/module.json', json_encode([
             'name' => 'Core',
             'alias' => 'core',
-            'namespace' => 'Modules\\Core'
+            'namespace' => 'Modules\\Core',
         ]));
     }
 

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -2,6 +2,7 @@
 
 namespace Mhmiton\LaravelModulesLivewire\Tests\Feature;
 
+use Mhmiton\LaravelModulesLivewire\LaravelModulesLivewireServiceProvider;
 use Mhmiton\LaravelModulesLivewire\Tests\TestCase;
 
 class ExampleTest extends TestCase
@@ -12,7 +13,7 @@ class ExampleTest extends TestCase
     public function test_package_can_be_loaded(): void
     {
         // Test that the service provider can be registered
-        $this->app->register(\Mhmiton\LaravelModulesLivewire\LaravelModulesLivewireServiceProvider::class);
+        $this->app->register(LaravelModulesLivewireServiceProvider::class);
 
         // Test that the config is available
         $config = config('modules-livewire');

--- a/tests/Feature/IntegrationTest.php
+++ b/tests/Feature/IntegrationTest.php
@@ -3,11 +3,12 @@
 namespace Mhmiton\LaravelModulesLivewire\Tests\Feature;
 
 use Illuminate\Support\Facades\File;
+use Mhmiton\LaravelModulesLivewire\LaravelModulesLivewireServiceProvider;
 use Mhmiton\LaravelModulesLivewire\Tests\TestCase;
 
 class IntegrationTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -26,7 +27,7 @@ class IntegrationTest extends TestCase
     public function test_package_can_be_installed_and_configured()
     {
         // Test that the service provider can be registered
-        $this->app->register(\Mhmiton\LaravelModulesLivewire\LaravelModulesLivewireServiceProvider::class);
+        $this->app->register(LaravelModulesLivewireServiceProvider::class);
 
         // Test that the config is available
         $config = config('modules-livewire');
@@ -50,9 +51,9 @@ class IntegrationTest extends TestCase
     {
         $this->artisan('module:make-livewire', [
             'component' => 'Pages/HomePage',
-            'module' => 'Core'
+            'module' => 'Core',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
 
         $this->assertFileExists(base_path('Modules/Core/app/Livewire/Pages/HomePage.php'));
         $classContent = File::get(base_path('Modules/Core/app/Livewire/Pages/HomePage.php'));
@@ -63,9 +64,9 @@ class IntegrationTest extends TestCase
     {
         $this->artisan('module:make-livewire-form', [
             'component' => 'Forms/ContactForm',
-            'module' => 'Core'
+            'module' => 'Core',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
 
         $this->assertFileExists(base_path('Modules/Core/app/Livewire/Forms/ContactForm.php'));
         $classContent = File::get(base_path('Modules/Core/app/Livewire/Forms/ContactForm.php'));
@@ -76,9 +77,9 @@ class IntegrationTest extends TestCase
     {
         $this->artisan('module:make-volt', [
             'component' => 'volt.counter',
-            'module' => 'Core'
+            'module' => 'Core',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
     }
 
     public function test_can_create_inline_component_integration()
@@ -86,9 +87,9 @@ class IntegrationTest extends TestCase
         $this->artisan('module:make-livewire', [
             'component' => 'Pages/AboutPage',
             'module' => 'Core',
-            '--inline' => true
+            '--inline' => true,
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
 
         $this->assertFileExists(base_path('Modules/Core/app/Livewire/Pages/AboutPage.php'));
         $this->assertFileDoesNotExist(base_path('Modules/Core/resources/views/livewire/pages/about-page.blade.php'));
@@ -99,9 +100,9 @@ class IntegrationTest extends TestCase
         $this->artisan('module:make-livewire', [
             'component' => 'Pages/ContactPage',
             'module' => 'Core',
-            '--view' => 'pages/contact'
+            '--view' => 'pages/contact',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
 
         $this->assertFileExists(base_path('Modules/Core/resources/views/livewire/pages/contact.blade.php'));
     }
@@ -111,14 +112,14 @@ class IntegrationTest extends TestCase
         // Create custom stub directory
         $stubPath = base_path('stubs/modules-livewire/custom');
         File::makeDirectory($stubPath, 0755, true, true);
-        File::put($stubPath . '/livewire.stub', '<?php namespace {{ namespace }}; class {{ class }} { }');
+        File::put($stubPath.'/livewire.stub', '<?php namespace {{ namespace }}; class {{ class }} { }');
 
         $this->artisan('module:make-livewire', [
             'component' => 'Pages/CustomPage',
             'module' => 'Core',
-            '--stub' => 'custom'
+            '--stub' => 'custom',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
 
         // Clean up
         File::deleteDirectory($stubPath);
@@ -129,9 +130,9 @@ class IntegrationTest extends TestCase
         // Create the component first
         $this->artisan('module:make-livewire', [
             'component' => 'Pages/TestPage',
-            'module' => 'Core'
+            'module' => 'Core',
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
 
         // Modify the file to test force overwrite
         $filePath = base_path('Modules/Core/app/Livewire/Pages/TestPage.php');
@@ -141,9 +142,9 @@ class IntegrationTest extends TestCase
         $this->artisan('module:make-livewire', [
             'component' => 'Pages/TestPage',
             'module' => 'Core',
-            '--force' => true
+            '--force' => true,
         ])
-        ->assertExitCode(0);
+            ->assertExitCode(0);
 
         // Check that the file was overwritten
         $content = File::get($filePath);
@@ -154,10 +155,10 @@ class IntegrationTest extends TestCase
     {
         $this->artisan('module:make-livewire', [
             'component' => 'Pages/AboutPage',
-            'module' => 'Core'
+            'module' => 'Core',
         ])
-        ->expectsOutput('TAG: <livewire:core::pages.about-page />')
-        ->assertExitCode(0);
+            ->expectsOutput('TAG: <livewire:core::pages.about-page />')
+            ->assertExitCode(0);
     }
 
     protected function createTestModule()
@@ -165,25 +166,25 @@ class IntegrationTest extends TestCase
         $modulePath = base_path('Modules/Core');
 
         // Create module directory structure
-        File::makeDirectory($modulePath . '/app/Livewire', 0755, true, true);
-        File::makeDirectory($modulePath . '/resources/views/livewire', 0755, true, true);
+        File::makeDirectory($modulePath.'/app/Livewire', 0755, true, true);
+        File::makeDirectory($modulePath.'/resources/views/livewire', 0755, true, true);
 
         // Create module.json
-        File::put($modulePath . '/module.json', json_encode([
+        File::put($modulePath.'/module.json', json_encode([
             'name' => 'Core',
             'alias' => 'core',
-            'namespace' => 'Modules\\Core'
+            'namespace' => 'Modules\\Core',
         ]));
 
         // Create volt module structure
         $voltModulePath = base_path('modules/Core');
-        File::makeDirectory($voltModulePath . '/resources/views/livewire', 0755, true, true);
-        File::makeDirectory($voltModulePath . '/resources/views/pages', 0755, true, true);
+        File::makeDirectory($voltModulePath.'/resources/views/livewire', 0755, true, true);
+        File::makeDirectory($voltModulePath.'/resources/views/pages', 0755, true, true);
 
-        File::put($voltModulePath . '/module.json', json_encode([
+        File::put($voltModulePath.'/module.json', json_encode([
             'name' => 'Core',
             'alias' => 'core',
-            'namespace' => 'Modules\\Core'
+            'namespace' => 'Modules\\Core',
         ]));
     }
 

--- a/tests/Feature/Livewire/LivewireComponentRenderTest.php
+++ b/tests/Feature/Livewire/LivewireComponentRenderTest.php
@@ -3,12 +3,11 @@
 namespace Mhmiton\LaravelModulesLivewire\Tests\Feature\Livewire;
 
 use Livewire\Livewire;
-use Mhmiton\LaravelModulesLivewire\Providers\LivewireComponentServiceProvider;
 use Mhmiton\LaravelModulesLivewire\Tests\TestCase;
 
 class LivewireComponentRenderTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
     }

--- a/tests/Feature/Volt/VoltComponentRenderTest.php
+++ b/tests/Feature/Volt/VoltComponentRenderTest.php
@@ -6,7 +6,7 @@ use Mhmiton\LaravelModulesLivewire\Tests\TestCase;
 
 class VoltComponentRenderTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
     }
@@ -15,7 +15,7 @@ class VoltComponentRenderTest extends TestCase
     {
         $this->artisan('module:make-volt', [
             'component' => 'volt.counter',
-            'module' => 'Core'
+            'module' => 'Core',
         ]);
 
         $this->assertTrue(true);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,10 +4,10 @@ namespace Mhmiton\LaravelModulesLivewire\Tests;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\LivewireServiceProvider;
-use Mhmiton\LaravelModulesLivewire\LaravelModulesLivewireServiceProvider;
 use Mhmiton\LaravelModulesLivewire\Commands\LivewireMakeCommand;
 use Mhmiton\LaravelModulesLivewire\Commands\LivewireMakeFormCommand;
 use Mhmiton\LaravelModulesLivewire\Commands\VoltMakeCommand;
+use Mhmiton\LaravelModulesLivewire\LaravelModulesLivewireServiceProvider;
 use Mhmiton\LaravelModulesLivewire\Tests\Traits\InitModule;
 use Nwidart\Modules\LaravelModulesServiceProvider;
 use Orchestra\Testbench\TestCase as TestbenchTestCase;
@@ -23,7 +23,7 @@ class TestCase extends TestbenchTestCase
      */
     protected $enablesPackageDiscoveries = true;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -30,7 +30,7 @@ class ExampleTest extends TestCase
      */
     public function test_string_operations(): void
     {
-        $this->assertEquals('Hello World', 'Hello ' . 'World');
+        $this->assertEquals('Hello World', 'Hello '.'World');
         $this->assertEquals(5, strlen('Hello'));
         $this->assertEquals('HELLO', strtoupper('hello'));
     }

--- a/tests/Unit/LaravelModulesLivewireServiceProviderTest.php
+++ b/tests/Unit/LaravelModulesLivewireServiceProviderTest.php
@@ -9,7 +9,7 @@ class LaravelModulesLivewireServiceProviderTest extends TestCase
 {
     protected $provider;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Providers/LivewireComponentServiceProviderTest.php
+++ b/tests/Unit/Providers/LivewireComponentServiceProviderTest.php
@@ -9,7 +9,7 @@ class LivewireComponentServiceProviderTest extends TestCase
 {
     protected $provider;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -54,7 +54,7 @@ class LivewireComponentServiceProviderTest extends TestCase
         $result = $this->invokeMethod($this->provider, 'registerComponentDirectory', [
             '/nonexistent/directory',
             'Test\\Namespace',
-            'test::'
+            'test::',
         ]);
 
         $this->assertFalse($result);

--- a/tests/Unit/Support/DecomposerTest.php
+++ b/tests/Unit/Support/DecomposerTest.php
@@ -2,6 +2,7 @@
 
 namespace Mhmiton\LaravelModulesLivewire\Tests\Unit\Support;
 
+use Illuminate\Support\Collection;
 use Mhmiton\LaravelModulesLivewire\Support\Decomposer;
 use Mhmiton\LaravelModulesLivewire\Tests\TestCase;
 
@@ -11,7 +12,7 @@ class DecomposerTest extends TestCase
     {
         $data = Decomposer::getComposerData();
 
-        $this->assertInstanceOf(\Illuminate\Support\Collection::class, $data);
+        $this->assertInstanceOf(Collection::class, $data);
     }
 
     public function test_get_package_returns_null_for_nonexistent_package()
@@ -45,7 +46,7 @@ class DecomposerTest extends TestCase
         $this->assertIsBool($hasPackages);
     }
 
-            public function test_check_dependencies_returns_error_object_when_packages_missing()
+    public function test_check_dependencies_returns_error_object_when_packages_missing()
     {
         $result = Decomposer::checkDependencies(['nonexistent/package']);
 

--- a/tests/Unit/Support/ModuleVoltComponentRegistryTest.php
+++ b/tests/Unit/Support/ModuleVoltComponentRegistryTest.php
@@ -10,11 +10,11 @@ class ModuleVoltComponentRegistryTest extends TestCase
 {
     protected $registry;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
-        $this->registry = new ModuleVoltComponentRegistry();
+        $this->registry = new ModuleVoltComponentRegistry;
     }
 
     public function test_register_components_returns_false_when_volt_not_available()
@@ -54,10 +54,10 @@ class ModuleVoltComponentRegistryTest extends TestCase
     {
         // Create test directory structure
         $testPath = base_path('Modules/Core');
-        $viewPath = $testPath . '/resources/views/livewire/';
+        $viewPath = $testPath.'/resources/views/livewire/';
 
         File::makeDirectory($viewPath, 0755, true, true);
-        File::put($viewPath . 'test-component.blade.php', '<div>Test</div>');
+        File::put($viewPath.'test-component.blade.php', '<div>Test</div>');
 
         $components = $this->registry->getRegisterableComponents(
             $testPath,
@@ -76,10 +76,10 @@ class ModuleVoltComponentRegistryTest extends TestCase
     {
         // Create test directory structure
         $testPath = base_path('Modules/Core');
-        $viewPath = $testPath . '/resources/views/livewire/';
+        $viewPath = $testPath.'/resources/views/livewire/';
 
         File::makeDirectory($viewPath, 0755, true, true);
-        File::put($viewPath . 'test-component.txt', 'Test content');
+        File::put($viewPath.'test-component.txt', 'Test content');
 
         $components = $this->registry->getRegisterableComponents(
             $testPath,
@@ -98,10 +98,10 @@ class ModuleVoltComponentRegistryTest extends TestCase
     {
         // Create test directory structure
         $testPath = base_path('Modules/Core');
-        $viewPath = $testPath . '/resources/views/livewire/';
+        $viewPath = $testPath.'/resources/views/livewire/';
 
         File::makeDirectory($viewPath, 0755, true, true);
-        File::put($viewPath . 'test-component.blade.php', '<div>Test</div>');
+        File::put($viewPath.'test-component.blade.php', '<div>Test</div>');
 
         $components = $this->registry->getRegisterableComponents(
             $testPath,
@@ -125,10 +125,10 @@ class ModuleVoltComponentRegistryTest extends TestCase
     {
         // Create test directory structure
         $testPath = base_path('Modules/Core');
-        $viewPath = $testPath . '/resources/views/livewire/pages/';
+        $viewPath = $testPath.'/resources/views/livewire/pages/';
 
         File::makeDirectory($viewPath, 0755, true, true);
-        File::put($viewPath . 'about-page.blade.php', '<div>About</div>');
+        File::put($viewPath.'about-page.blade.php', '<div>About</div>');
 
         $components = $this->registry->getRegisterableComponents(
             $testPath,

--- a/tests/Unit/Traits/CommandHelperTest.php
+++ b/tests/Unit/Traits/CommandHelperTest.php
@@ -2,21 +2,27 @@
 
 namespace Mhmiton\LaravelModulesLivewire\Tests\Unit\Traits;
 
+use Illuminate\Console\Command;
 use Mhmiton\LaravelModulesLivewire\Tests\TestCase;
+use Mhmiton\LaravelModulesLivewire\Traits\CommandHelper;
 
 class CommandHelperTest extends TestCase
 {
     protected $command;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
-        $this->command = new class extends \Illuminate\Console\Command {
-            use \Mhmiton\LaravelModulesLivewire\Traits\CommandHelper;
+        $this->command = new class extends Command
+        {
+            use CommandHelper;
+
             protected $signature = 'test:command {component} {module}';
+
             protected $description = 'Test command';
 
             public $component;
+
             public $module;
 
             public function __construct()
@@ -26,7 +32,10 @@ class CommandHelperTest extends TestCase
                 $this->module = 'Core';
             }
 
-            public function handle() { return 0; }
+            public function handle()
+            {
+                return 0;
+            }
 
             // Mock the input methods
             public function argument($key = null)
@@ -37,6 +46,7 @@ class CommandHelperTest extends TestCase
                 if ($key === 'component') {
                     return 'TestComponent';
                 }
+
                 return null;
             }
 
@@ -48,6 +58,7 @@ class CommandHelperTest extends TestCase
                 if ($key === 'inline') {
                     return false;
                 }
+
                 return null;
             }
         };

--- a/tests/Unit/View/ModuleVoltViewFactoryTest.php
+++ b/tests/Unit/View/ModuleVoltViewFactoryTest.php
@@ -2,14 +2,18 @@
 
 namespace Mhmiton\LaravelModulesLivewire\Tests\Unit\View;
 
-use Mhmiton\LaravelModulesLivewire\View\ModuleVoltViewFactory;
+use Illuminate\View\Engines\EngineResolver;
+use Illuminate\View\Factory;
+use Illuminate\View\FileViewFinder;
+use Illuminate\View\View;
 use Mhmiton\LaravelModulesLivewire\Tests\TestCase;
+use Mhmiton\LaravelModulesLivewire\View\ModuleVoltViewFactory;
 
 class ModuleVoltViewFactoryTest extends TestCase
 {
     protected $factory;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -27,21 +31,21 @@ class ModuleVoltViewFactoryTest extends TestCase
 
     public function test_factory_extends_view_factory()
     {
-        $this->assertInstanceOf(\Illuminate\View\Factory::class, $this->factory);
+        $this->assertInstanceOf(Factory::class, $this->factory);
     }
 
     public function test_factory_has_finder()
     {
         $finder = $this->factory->getFinder();
 
-        $this->assertInstanceOf(\Illuminate\View\FileViewFinder::class, $finder);
+        $this->assertInstanceOf(FileViewFinder::class, $finder);
     }
 
     public function test_factory_has_engine_resolver()
     {
         $resolver = $this->factory->getEngineResolver();
 
-        $this->assertInstanceOf(\Illuminate\View\Engines\EngineResolver::class, $resolver);
+        $this->assertInstanceOf(EngineResolver::class, $resolver);
     }
 
     public function test_factory_can_add_namespace()
@@ -64,7 +68,7 @@ class ModuleVoltViewFactoryTest extends TestCase
         $viewPath = base_path('resources/views/test-view.blade.php');
         $viewDir = dirname($viewPath);
 
-        if (!is_dir($viewDir)) {
+        if (! is_dir($viewDir)) {
             mkdir($viewDir, 0755, true);
         }
 
@@ -72,7 +76,7 @@ class ModuleVoltViewFactoryTest extends TestCase
 
         try {
             $view = $this->factory->make('test-view');
-            $this->assertInstanceOf(\Illuminate\View\View::class, $view);
+            $this->assertInstanceOf(View::class, $view);
         } catch (\Exception $e) {
             // View might not be found, which is expected in test environment
             $this->assertTrue(true);


### PR DESCRIPTION
Adds laravel/pint as a dev dependency with a `composer lint` script, then applies its formatting rules project-wide:

- Replace inline FQCNs with imported aliases (Module, Volt, ComponentFactory, etc.)
- Remove unnecessary parentheses from zero-argument instantiations (new Foo vs new Foo())
- Normalise string concatenation to single-quoted strings where no interpolation is needed
- Fix indentation of chained method calls in ModuleVoltComponentRegistry
- Sort import statements alphabetically in several files
- Change `public function setUp()` to `protected function setUp()` across all test classes
- Fix misindented test method in DecomposerTest
- Minor formatting cleanup in anonymous class in CommandHelperTest